### PR TITLE
Add MIDI device attached/detached listeners

### DIFF
--- a/javax.sound.midi/src/jp/kshoji/javax/sound/midi/MidiSystem.java
+++ b/javax.sound.midi/src/jp/kshoji/javax/sound/midi/MidiSystem.java
@@ -17,6 +17,8 @@ import jp.kshoji.javax.sound.midi.MidiDevice.Info;
 import jp.kshoji.javax.sound.midi.impl.SequencerImpl;
 import jp.kshoji.javax.sound.midi.io.StandardMidiFileReader;
 import jp.kshoji.javax.sound.midi.io.StandardMidiFileWriter;
+import jp.kshoji.javax.sound.midi.listener.OnMidiDeviceAttachedListener;
+import jp.kshoji.javax.sound.midi.listener.OnMidiDeviceDetachedListener;
 
 /**
  * MidiSystem porting for Android
@@ -28,6 +30,8 @@ public final class MidiSystem {
     private static final Collection<Synthesizer> synthesizers = new HashSet<Synthesizer>();
     private static final StandardMidiFileReader standardMidiFileReader = new StandardMidiFileReader();
     private static final StandardMidiFileWriter standardMidiFileWriter = new StandardMidiFileWriter();
+    private static final Collection<OnMidiDeviceAttachedListener> attachedListeners = new HashSet<OnMidiDeviceAttachedListener>();
+    private static final Collection<OnMidiDeviceDetachedListener> detachedListeners = new HashSet<OnMidiDeviceDetachedListener>();
 
     /**
      * Add a {@link jp.kshoji.javax.sound.midi.MidiDevice} to the {@link jp.kshoji.javax.sound.midi.MidiSystem}
@@ -37,6 +41,11 @@ public final class MidiSystem {
     public static void addMidiDevice(@NonNull final MidiDevice midiDevice) {
         synchronized (midiDevices) {
             midiDevices.add(midiDevice);
+        }
+        synchronized (attachedListeners) {
+            for (OnMidiDeviceAttachedListener listener: attachedListeners) {
+                listener.onMidiDeviceAttached(midiDevice.getDeviceInfo());
+            }
         }
     }
 
@@ -48,6 +57,11 @@ public final class MidiSystem {
     public static void removeMidiDevice(@NonNull final MidiDevice midiDevice) {
         synchronized (midiDevices) {
             midiDevices.remove(midiDevice);
+        }
+        synchronized (detachedListeners) {
+            for (OnMidiDeviceDetachedListener listener: detachedListeners) {
+                listener.onMidiDeviceDetached(midiDevice.getDeviceInfo());
+            }
         }
     }
 
@@ -440,4 +454,66 @@ public final class MidiSystem {
     public static int write(@NonNull final Sequence sequence, final int fileType, @NonNull final OutputStream outputStream) throws IOException {
 		return standardMidiFileWriter.write(sequence, fileType, outputStream);
 	}
+
+    /**
+     * Adds the specified {@link OnMidiDeviceAttachedListener} to receive events when devices are attached.
+     * If the listener is null, no exception is thrown and no action is performed.
+     *
+     * @param listener - the listener
+     * @see #removeDeviceAttachedListener(OnMidiDeviceAttachedListener)
+     */
+    public static void addDeviceAttachedListener(@NonNull OnMidiDeviceAttachedListener listener) {
+        if (listener == null)
+            return;
+        synchronized (attachedListeners) {
+            attachedListeners.add(listener);
+        }
+    }
+
+    /**
+     * Removes the specified {@link OnMidiDeviceAttachedListener} so that it no longer receives events when devices are attached.
+     * This method performs no function, nor does it throw an exception, if the listener specified by the argument was not previously added.
+     * If the listener is null, no exception is thrown and no action is performed.
+     *
+     * @param listener - the listener
+     * @see #addDeviceAttachedListener(OnMidiDeviceAttachedListener)
+     */
+    public static void removeDeviceAttachedListener(@NonNull OnMidiDeviceAttachedListener listener) {
+        if (listener == null)
+            return;
+        synchronized (attachedListeners) {
+            attachedListeners.remove(listener);
+        }
+    }
+
+    /**
+     * Adds the specified {@link OnMidiDeviceDetachedListener} to receive events when devices are detached.
+     * If the listener is null, no exception is thrown and no action is performed.
+     *
+     * @param listener - the listener
+     * @see #removeDeviceDetachedListener(OnMidiDeviceDetachedListener)
+     */
+    public static void addDeviceDetachedListener(@NonNull OnMidiDeviceDetachedListener listener) {
+        if (listener == null)
+            return;
+        synchronized (detachedListeners) {
+            detachedListeners.add(listener);
+        }
+    }
+
+    /**
+     * Removes the specified {@link OnMidiDeviceDetachedListener} so that it no longer receives events when devices are detached.
+     * This method performs no function, nor does it throw an exception, if the listener specified by the argument was not previously added.
+     * If the listener is null, no exception is thrown and no action is performed.
+     *
+     * @param listener - the listener
+     * @see #addDeviceDetachedListener(OnMidiDeviceDetachedListener)
+     */
+    public static void removeDeviceDetachedListener(@NonNull OnMidiDeviceDetachedListener listener) {
+        if (listener == null)
+            return;
+        synchronized (detachedListeners) {
+            detachedListeners.remove(listener);
+        }
+    }
 }

--- a/javax.sound.midi/src/jp/kshoji/javax/sound/midi/listener/OnMidiDeviceAttachedListener.java
+++ b/javax.sound.midi/src/jp/kshoji/javax/sound/midi/listener/OnMidiDeviceAttachedListener.java
@@ -1,0 +1,18 @@
+package jp.kshoji.javax.sound.midi.listener;
+
+import android.support.annotation.NonNull;
+
+import jp.kshoji.javax.sound.midi.MidiDevice;
+
+/**
+ * Listener for MIDI attached events
+ */
+public interface OnMidiDeviceAttachedListener {
+
+    /**
+     * MIDI device has been attached
+     *
+     * @param midiDevice attached MIDI device
+     */
+    void onMidiDeviceAttached(@NonNull MidiDevice.Info midiDeviceInfo);
+}

--- a/javax.sound.midi/src/jp/kshoji/javax/sound/midi/listener/OnMidiDeviceDetachedListener.java
+++ b/javax.sound.midi/src/jp/kshoji/javax/sound/midi/listener/OnMidiDeviceDetachedListener.java
@@ -1,0 +1,18 @@
+package jp.kshoji.javax.sound.midi.listener;
+
+import android.support.annotation.NonNull;
+
+import jp.kshoji.javax.sound.midi.MidiDevice;
+
+/**
+ * Listener for MIDI detached events
+ */
+public interface OnMidiDeviceDetachedListener {
+
+    /**
+     * MIDI device has been detached
+     *
+     * @param midiDevice detached MIDI device
+     */
+    void onMidiDeviceDetached(@NonNull MidiDevice.Info midiDeviceInfo);
+}


### PR DESCRIPTION
This is what I am currently using as an implementation of #9 (my own feature request :smile:).

Of course, the _real_ `javax.sound.midi.MidiSystem` will probably never be extended to support hot-plugging devices, but there's value nonetheless in having this API here.
