### PR TITLE
Fix JitPack build

### DIFF
--- a/javax.sound.midi/build.gradle
+++ b/javax.sound.midi/build.gradle
@@ -40,10 +40,15 @@ android {
 
 apply plugin: 'maven'
 group = 'jp.kshoji'
+def pomVersion = '0.0.4'
 uploadArchives {
     repositories.mavenDeployer {
         repository url: 'file://' + file('repository').absolutePath
-        pom.version = '0.0.4'
+        pom.version = "${pomVersion}"
+        pom.artifactId = 'javax-sound-midi'
+    }
+    repositories.mavenInstaller {
+        pom.version = "${pomVersion}"
         pom.artifactId = 'javax-sound-midi'
     }
 }


### PR DESCRIPTION
This fixes #20 

I added `repositories.mavenInstaller` and it seems to copy the build locally now. I also created a variable for `pom.version` so you only have to change it in one place. I didn't create a variable for `pom.artifactId` because I figured you won't change it.

I tested it out in my fork and the JitPack build works now: https://jitpack.io/com/github/bmaupin/javax.sound.midi-for-Android/fix-jitpack-build-v0.0.4-g8496468-2/build.log

I also tested it out in my project with the fix from the fork and it works:

```groovy
allprojects {
    repositories {
        maven { url "https://jitpack.io" }
```

```groovy
dependencies {
    implementation 'com.github.bmaupin:javax.sound.midi-for-Android:fix-jitpack-build-SNAPSHOT'
```

Thanks!